### PR TITLE
Kirkstone

### DIFF
--- a/recipes-devtools/vsdbg/vsdbg_17.2.10518.1.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.2.10518.1.inc
@@ -9,12 +9,12 @@ SRC_URI += "https://vsdebugger.blob.core.windows.net/vsdbg-17-2-10518-1/GetVsDbg
 SRC_URI[script.md5sum] = "76ffe243ffb06b6b1a8a7f8c7bf31776"
 SRC_URI[script.sha256sum] = "2608424ae05550a24ac9b767a997635de1e87fe551156536d03356da421f4c64"
 
-RDEPENDS_${PN} += " procps"
+RDEPENDS:${PN} += " procps"
 
 DOTNET_RUNTIME_ARCH = "none"
-DOTNET_RUNTIME_ARCH_arm = "arm"
-DOTNET_RUNTIME_ARCH_x86_64 = "x64"
-DOTNET_RUNTIME_ARCH_aarch64 = "arm64"
+DOTNET_RUNTIME_ARCH:arm = "arm"
+DOTNET_RUNTIME_ARCH:x86_64 = "x64"
+DOTNET_RUNTIME_ARCH:aarch64 = "arm64"
 
 # This is here because it doesn't seem like bitbake likes ${PV} used in require statements.
 require recipes-devtools/vsdbg/vsdbg_17.2.10518.1_${DOTNET_RUNTIME_ARCH}.inc

--- a/recipes-devtools/vsdbg/vsdbg_17.x.inc
+++ b/recipes-devtools/vsdbg/vsdbg_17.x.inc
@@ -191,9 +191,5 @@ do_install:prepend () {
 	for file in ${S}/*.vsdconfig; do
 		install -m 0644 "$file" ${D}${ROOT_HOME}/.vs-debugger/vs2022/
 	done
-
-	# Setup a link so that vs2019 will also work.
-	cd ${D}${ROOT_HOME}/.vs-debugger/
-	ln -sf ${ROOT_HOME}/.vs-debugger/vs2022 vs2019
 }
 

--- a/recipes-runtime/aspnet-core/aspnet-core_6.x.x.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_6.x.x.inc
@@ -11,6 +11,7 @@ S = "${WORKDIR}/aspnet-${PV}"
 
 require recipes-runtime/aspnet-core/aspnet-core_mit_6.x.x.inc
 
+# FIXME: patchelf-native must be removed if hack in do_install:append not required
 DEPENDS = "zlib patchelf-native"
 RDEPENDS:${PN} = "lttng-tools lttng-ust zlib icu libssl"
 
@@ -71,7 +72,8 @@ do_install:append() {
 
 	cd ${D}${bindir}
 	ln -s ../share/dotnet/dotnet ${D}${bindir}/dotnet
-
+    
+    # FIXME: must be removed if the liblttng-ust library issue was fixed
     # Hack to fix liblttng-ust dependency issues
     patchelf --remove-needed liblttng-ust.so.0 ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${PV}/libcoreclrtraceptprovider.so
 }

--- a/recipes-runtime/aspnet-core/aspnet-core_6.x.x.inc
+++ b/recipes-runtime/aspnet-core/aspnet-core_6.x.x.inc
@@ -11,7 +11,7 @@ S = "${WORKDIR}/aspnet-${PV}"
 
 require recipes-runtime/aspnet-core/aspnet-core_mit_6.x.x.inc
 
-DEPENDS = "zlib"
+DEPENDS = "zlib patchelf-native"
 RDEPENDS:${PN} = "lttng-tools lttng-ust zlib icu libssl"
 
 INSANE_SKIP:${PN} += "already-stripped libdir textrel"
@@ -71,5 +71,8 @@ do_install:append() {
 
 	cd ${D}${bindir}
 	ln -s ../share/dotnet/dotnet ${D}${bindir}/dotnet
+
+    # Hack to fix liblttng-ust dependency issues
+    patchelf --remove-needed liblttng-ust.so.0 ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${PV}/libcoreclrtraceptprovider.so
 }
 

--- a/recipes-runtime/dotnet-core/dotnet-core_6.x.x.inc
+++ b/recipes-runtime/dotnet-core/dotnet-core_6.x.x.inc
@@ -11,7 +11,8 @@ S = "${WORKDIR}/dotnet-${PV}"
 
 require recipes-runtime/dotnet-core/dotnet-core_mit_6.x.x.inc
 
-DEPENDS = "zlib"
+# FIXME: patchelf-native must be removed if hack in do_install:append not required
+DEPENDS = "zlib patchelf-native"
 RDEPENDS:${PN} = "lttng-tools lttng-ust zlib icu libssl"
 
 INSANE_SKIP:${PN} += "already-stripped libdir textrel"
@@ -58,5 +59,9 @@ do_install:append() {
 
 	cd ${D}${bindir}
 	ln -s ../share/dotnet/dotnet ${D}${bindir}/dotnet
+
+    # FIXME: must be removed if the liblttng-ust library issue was fixed
+    # Hack to fix liblttng-ust dependency issues
+    patchelf --remove-needed liblttng-ust.so.0 ${D}${datadir}/dotnet/shared/Microsoft.NETCore.App/${PV}/libcoreclrtraceptprovider.so
 }
 


### PR DESCRIPTION
# This fixes vsdbg, aspnet-core and dotnet-core syntax and build issues for branch kirkstone and pull request #47
## Summary
I was facing the issue thas vsdbg and aspnet-core were unbuildable. 
vsdbg used old Bitbake syntax and the link to use visual Studio 2019 causes errors. 
aspnet-core and dotnet-core had issues with liblttng-ust.so.0.

@jacobusvanzyl  please confirm the changes takes affekt and add them to your pull request #47.

## aspnet-core and dotnet-core fix for liblttng-ust.so.0 issue 
### Fixed errors
**aspnet-core:**
```
ERROR: aspnet-core-6.0.8-r0 do_package_qa: QA Issue: /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.8/libcoreclrtraceptprovider.so contained in package aspnet-core requires liblttng-ust.so.0()(64bit), but no providers found in RDEPENDS:aspnet-core? [file-rdeps]
ERROR: aspnet-core-6.0.8-r0 do_package_qa: Fatal QA errors were found, failing task.
```
**dotnet-core**
```
ERROR: dotnet-core-6.0.8-r0 do_package_qa: QA Issue: /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.8/libcoreclrtraceptprovider.so contained in package dotnet-core requires liblttng-ust.so.0()(64bit), but no providers found in RDEPENDS:dotnet-core? [file-rdeps]
ERROR: dotnet-core-6.0.8-r0 do_package_qa: Fatal QA errors were found, failing task.
```

### Solution
I've added a hack to files recipes-runtime/aspnet-core/aspnet-core_6.x.inc and recipes-runtime/dotnet-core/dotnet-core_6.x.x.inc which  removes the liblttng-ust.so-0 library in libcoreclrtraceptprovider.so that causes this error. This hack must be removed if the issue was fixed.
**Changes:**
* [recipes-runtime/aspnet-core/aspnet-core_6.x.x.inc](https://github.com/jacobusvanzyl/meta-dotnet-core/commit/3822b8f8eae02deffeb63a78f8b8540fd180f73f#diff-141f9e39a1094fb3a38460c4bb61c960cf44fef1a93a9f0004fb69b79f904fd0)
* [recipes-runtime/aspnet-core/aspnet-core_6.x.x.inc](https://github.com/jacobusvanzyl/meta-dotnet-core/commit/fafde7920a5effbd96f3591f8f12d0d0cb02218f#diff-141f9e39a1094fb3a38460c4bb61c960cf44fef1a93a9f0004fb69b79f904fd0)
* [recipes-runtime/dotnet-core/dotnet-core_6.x.x.inc](https://github.com/jacobusvanzyl/meta-dotnet-core/commit/0571bed0dc9019c2efa8441ad33aeaed2dd23e11#diff-9ae420627a99fbb6491ff6a4ac93bfafdfba197e4405bfb4413611e08f43c535)



## vsdbg 
### Fixed errors
**Visual Studio 2019 link issue:**
@jacobusvanzyl Visual Studio 2019 is obsolete with release of Visual Studio 2022. You also can comment the part of link creation out in file [recipes-devtools/vsdbg/vsdbg_17.x.inc](https://github.com/jacobusvanzyl/meta-dotnet-core/pull/1/files#diff-8e17d495e9be129da3659e55d3bdc3f9ba01ec4bb51acabeab590208e06da7cb) for users which want tot use it.
**I highly recommend to disable Visual Studio 2019 support by default.**
```
 absolute symlink: /root/.vs-debugger/vs2019 -> /root/.vs-debugger/vs2022
 Recognition of file /home/test/yocto/build/tmp/work/cortexa53-crypto-linux/vsdbg/17.2.10518.1-r0/package/root/.vs-debugger/vs2019 failed: mode 120777 broken symbolic link to /root/.vs-debugger/vs2022 (Permission denied)
```
**vsdbg old syntax issues**
```
install: cannot stat '/home/test/yocto/build/tmp/work/cortexa53-crypto-seconorth-linux/vsdbg/17.2.10518.1-r0/vsdbg-17.2.10518.1/vsdbg': No such file or directory
```

## Solution
**Changes:**
*  [recipes-devtools/vsdbg/vsdbg_17.2.10518.1.inc](https://github.com/jacobusvanzyl/meta-dotnet-core/commit/60dcb310badfae99ea948787ca89bfb27fb2fc94#diff-4c2866bf62f32c5074e0c2199bc83564544af7db31fa550dd522b3844dbba53e)
* [recipes-devtools/vsdbg/vsdbg_17.x.inc](https://github.com/jacobusvanzyl/meta-dotnet-core/commit/6b0617ceed6086b5b53c362f5c176ddfb98c8946#diff-8e17d495e9be129da3659e55d3bdc3f9ba01ec4bb51acabeab590208e06da7cb)